### PR TITLE
cfg_hide_pools is not used for the initial building of the @pools arr…

### DIFF
--- a/phpfpm-multi
+++ b/phpfpm-multi
@@ -142,6 +142,10 @@ if (opendir my $dh, $cfg_pooldir) {
       next;
     }
 
+    if ( grep( /^$pool->{pool}$/, @cfg_hide_pools ) ) {
+      next;
+    }
+
     # Replace $pool in socket and pm.status_path
     $pool->{socket} =~ s/\$pool/$pool->{pool}/g;
     $pool->{statuspath} =~ s/\$pool/$pool->{pool}/g;


### PR DESCRIPTION
cfg_hide_pools is not used for the initial building of the @pools array. There might be servers where there is a config, but no running socket due to automation or temporary shutdown.

An explicit usage of cfg_hide_pools should not be used at all, as cgi-fcgi can't connect if it's not there